### PR TITLE
Bump files with dotnet-file sync

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -54,8 +54,41 @@ jobs:
       - name: 🙏 build
         run: dotnet build -m:1 -p:VersionLabel="$GITHUB_REF.$GITHUB_RUN_NUMBER"
 
+      - name: ⚙ GNU grep
+        if: matrix.os == 'macOS-latest'
+        run: |
+          brew install grep
+          echo 'export PATH="/usr/local/opt/grep/libexec/gnubin:$PATH"' >> .bash_profile
+
       - name: 🧪 test
-        run: dotnet test --no-build -m:1 --blame-hang --blame-hang-timeout 5m
+        shell: bash --noprofile --norc {0}
+        env:
+          LC_ALL: en_US.utf8
+        run: |
+          [ -f .bash_profile ] && source .bash_profile
+          counter=0
+          exitcode=0
+          reset="\e[0m"
+          warn="\e[0;33m"
+          while [ $counter -lt 6 ]
+          do
+              if [ $filter ]
+              then
+                  echo -e "${warn}Retry $counter for $filter ${reset}"
+              fi
+              # run test and forward output also to a file in addition to stdout (tee command)
+              dotnet test --no-build -m:1 --blame-hang --blame-hang-timeout 5m --filter=$filter | tee ./output.log
+              # capture dotnet test exit status, different from tee
+              exitcode=${PIPESTATUS[0]}
+              if [ $exitcode == 0 ]
+              then
+                  exit 0
+              fi
+              # cat output, get failed test names, join as DisplayName=TEST with |, remove trailing |.
+              filter=$(cat ./output.log | grep -o -P '(?<=\sFailed\s)\w*' | awk 'BEGIN { ORS="|" } { print("DisplayName=" $0) }' | grep -o -P '.*(?=\|$)')
+              ((counter++))
+          done
+          exit $exitcode
 
       - name: 📦 pack
         run: dotnet pack -m:1 -p:VersionLabel="$GITHUB_REF.$GITHUB_RUN_NUMBER"

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -24,8 +24,41 @@ jobs:
       - name: 🙏 build
         run: dotnet build -m:1 -p:version=${GITHUB_REF#refs/*/v}
 
+      - name: ⚙ GNU grep
+        if: matrix.os == 'macOS-latest'
+        run: |
+          brew install grep
+          echo 'export PATH="/usr/local/opt/grep/libexec/gnubin:$PATH"' >> .bash_profile
+
       - name: 🧪 test
-        run: dotnet test --no-build -m:1
+        shell: bash --noprofile --norc {0}
+        env:
+          LC_ALL: en_US.utf8
+        run: |
+          [ -f .bash_profile ] && source .bash_profile
+          counter=0
+          exitcode=0
+          reset="\e[0m"
+          warn="\e[0;33m"
+          while [ $counter -lt 6 ]
+          do
+              if [ $filter ]
+              then
+                  echo -e "${warn}Retry $counter for $filter ${reset}"
+              fi
+              # run test and forward output also to a file in addition to stdout (tee command)
+              dotnet test --no-build -m:1 --blame-hang --blame-hang-timeout 5m --filter=$filter | tee ./output.log
+              # capture dotnet test exit status, different from tee
+              exitcode=${PIPESTATUS[0]}
+              if [ $exitcode == 0 ]
+              then
+                  exit 0
+              fi
+              # cat output, get failed test names, join as DisplayName=TEST with |, remove trailing |.
+              filter=$(cat ./output.log | grep -o -P '(?<=\sFailed\s)\w*' | awk 'BEGIN { ORS="|" } { print("DisplayName=" $0) }' | grep -o -P '.*(?=\|$)')
+              ((counter++))
+          done
+          exit $exitcode
 
       - name: 📦 pack
         run: dotnet pack -m:1 -p:version=${GITHUB_REF#refs/*/v}

--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@ bin
 obj
 artifacts
 pack
+TestResults
 .vs
 .vscode
 

--- a/.netconfig
+++ b/.netconfig
@@ -49,8 +49,8 @@
 	weak
 [file ".github/workflows/build.yml"]
 	url = https://github.com/devlooped/oss/blob/main/.github/workflows/build.yml
-	sha = fc5889d5387e2d5aa7aba279b2aa12251cf08cb2
-	etag = 91e9a208cd134bd7b71d7419800c613bc50a30e21e605607528721f2acdeab86
+	sha = 964caa363fe9cd8ef01c8a5d8e3fd07d1aed35ae
+	etag = ef5ed75b1e23292dd7af196a11f04760aa5ad4a3f374095395da9abc2de3f24f
 	weak
 [file ".github/workflows/changelog.yml"]
 	url = https://github.com/devlooped/oss/blob/main/.github/workflows/changelog.yml
@@ -64,8 +64,8 @@
 	weak
 [file ".github/workflows/publish.yml"]
 	url = https://github.com/devlooped/oss/blob/main/.github/workflows/publish.yml
-	sha = 55c0b32601e94e1eed35028a0cad510c6bcbb265
-	etag = ad8681ee3f191f796944135772b74565c470e349464e793aa664c888f7784b7a
+	sha = 964caa363fe9cd8ef01c8a5d8e3fd07d1aed35ae
+	etag = d6369e92c55eb78322ff39d26fc4ef1996b691a8ce05392395ab393e14ddb940
 	weak
 [file ".github/workflows/release-notes.yml"]
 	url = https://github.com/devlooped/oss/blob/main/.github/workflows/release-notes.yml
@@ -79,8 +79,8 @@
 	weak
 [file ".gitignore"]
 	url = https://github.com/devlooped/oss/blob/main/.gitignore
-	sha = fa83a5161ba52bc5d510ce0ba75ee0b1f8d4bc63
-	etag = 925782b685859e07040442303b411bebd1c75b4fe4e075f547e067f33f323814
+	sha = a9f9d3f5db6dd0714f52da61e35ab233fd0a1642
+	etag = e6ba96dc8c185a4e9c64f7c2c8003ef86e8f73624865ff7f6ae955aad55a164e
 	weak
 [file "Directory.Build.rsp"]
 	url = https://github.com/devlooped/oss/blob/main/Directory.Build.rsp


### PR DESCRIPTION
# devlooped/oss

- Automatically retry failed tests up to 5 times https://github.com/devlooped/oss/commit/8bc16a7
- Ensure GNU grep is used on macOS https://github.com/devlooped/oss/commit/964caa3
- Ignore TestResults folders https://github.com/devlooped/oss/commit/a9f9d3f