### PR TITLE
Bump files with dotnet-file sync

### DIFF
--- a/.github/.github_changelog_generator
+++ b/.github/.github_changelog_generator
@@ -1,5 +1,4 @@
 usernames-as-github-logins=true
-header-label=
 issues_wo_labels=true
 pr_wo_labels=true
 exclude-labels=bydesign,dependencies,duplicate,question,invalid,wontfix,need info

--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -25,9 +25,9 @@ jobs:
           token: ${{ env.GH_TOKEN }}
 
       - name: ⚙ changelog
-        uses: faberNovel/github-changelog-generator-action@master
-        with:
-          options: --token ${{ secrets.GITHUB_TOKEN }} --o changelog.md
+        run: |
+          sudo gem install github_changelog_generator 
+          github_changelog_generator --user ${GITHUB_REPOSITORY%/*} --project ${GITHUB_REPOSITORY##*/} --token ${{ secrets.GITHUB_TOKEN }} --o changelog.md --config-file .github/.github_changelog_generator
 
       - name: 🚀 changelog
         run: |

--- a/.github/workflows/dotnet-file.yml
+++ b/.github/workflows/dotnet-file.yml
@@ -53,7 +53,7 @@ jobs:
           branch: dotnet-file-sync
           delete-branch: true
           labels: dependencies
-          commit-message: Bump files with dotnet-file sync
+          commit-message: ⬆️ Bump files with dotnet-file sync
           
             ${{ env.CHANGES }}
           title: "Bump files with dotnet-file sync"

--- a/.github/workflows/release-notes.yml
+++ b/.github/workflows/release-notes.yml
@@ -21,16 +21,16 @@ jobs:
         run: echo "SINCE_TAG=$(git describe --abbrev=0 --tags $(git rev-list --tags --skip=1 --max-count=1))" >> $GITHUB_ENV
 
       - name: ⚙ changelog
-        uses: faberNovel/github-changelog-generator-action@master
         if: env.SINCE_TAG != ''
-        with:
-          options: --token ${{ secrets.GITHUB_TOKEN }} --since-tag ${{ env.SINCE_TAG }} --o changelog.md
+        run: |
+          sudo gem install github_changelog_generator 
+          github_changelog_generator --since-tag ${{ env.SINCE_TAG }} --user ${GITHUB_REPOSITORY%/*} --project ${GITHUB_REPOSITORY##*/} --token ${{ secrets.GITHUB_TOKEN }} --o changelog.md --config-file .github/.github_changelog_generator
 
       - name: ⚙ changelog
-        uses: faberNovel/github-changelog-generator-action@master
         if: env.SINCE_TAG == ''
-        with:
-          options: --token ${{ secrets.GITHUB_TOKEN }} --o changelog.md
+        run: |
+          sudo gem install github_changelog_generator 
+          github_changelog_generator --user ${GITHUB_REPOSITORY%/*} --project ${GITHUB_REPOSITORY##*/} --token ${{ secrets.GITHUB_TOKEN }} --o changelog.md --config-file .github/.github_changelog_generator
 
       - name: 🖉 release
         shell: pwsh

--- a/.netconfig
+++ b/.netconfig
@@ -52,13 +52,13 @@
 	weak
 [file ".github/workflows/changelog.yml"]
 	url = https://github.com/devlooped/oss/blob/main/.github/workflows/changelog.yml
-	sha = 084aa7c36ee1c262ea2f9e83931068366a7b4312
-	etag = 1e17c477f9e26f83367870a18e3727a71dcbb49cd31d85e0cfcfe092202d3a66
+	sha = b7ce2bedba3fe467b8bc252c372cd36bbde259a5
+	etag = 99c02f817f1a2b6ffaec4f7c4cd1c60e6bfae966174568f8027a4a2f42a00e69
 	weak
 [file ".github/workflows/dotnet-file.yml"]
 	url = https://github.com/devlooped/oss/blob/main/.github/workflows/dotnet-file.yml
-	sha = 084aa7c36ee1c262ea2f9e83931068366a7b4312
-	etag = 501f8bf58287fdd7467701342f7251a015bc29664b494e7d81a71c0c55bee61f
+	sha = 2a39a426f66402e47c80818f92748a1bfd7d736c
+	etag = c424e4f9159bd5d4ccb3b65646a65eed5ad153f57111e3b56900ebce10194f3f
 	weak
 [file ".github/workflows/publish.yml"]
 	url = https://github.com/devlooped/oss/blob/main/.github/workflows/publish.yml
@@ -67,13 +67,8 @@
 	weak
 [file ".github/workflows/release-notes.yml"]
 	url = https://github.com/devlooped/oss/blob/main/.github/workflows/release-notes.yml
-	sha = b07aaab94cccdaa7cd42eb17c0390ffacb6fbee8
-	etag = b01d73895c1f62e16cfd2a78e36bbf82c4d1332ed747c50002695997b92caf58
-	weak
-[file ".github_changelog_generator"]
-	url = https://github.com/devlooped/oss/blob/main/.github_changelog_generator
-	sha = a9a7616a242f5ba5c910c3f1c93bb38c4b2fbd8d
-	etag = 73c55fc67df88885e402f87d24c36cd5df6a08604ae1c3256ee0413d115975c6
+	sha = b7ce2bedba3fe467b8bc252c372cd36bbde259a5
+	etag = f9e85892ecefdc98584d9a90c3b29e63e910f161b8761a51eaeb94dfa9bd3e4f
 	weak
 [file ".gitignore"]
 	url = https://github.com/devlooped/oss/blob/main/.gitignore
@@ -112,13 +107,13 @@
 	weak
 [file "src/Directory.Build.props"]
 	url = https://github.com/devlooped/oss/blob/main/src/Directory.Build.props
-	sha = e2606657b68d2980cc3cae181c59baa3d847ab75
-	etag = a44fa4e71022b1c5f9684ec65815f69b47d51d0289e58bd9396606bd88e4244a
+	sha = cc6922f63e2bd520a75f46592cfb38cec02aaccd
+	etag = 743fd7845e40d9aef662f858a2d48dbfec9a10977e15394f45e331841a3c0dfd
 	weak
 [file "src/Directory.Build.targets"]
 	url = https://github.com/devlooped/oss/blob/main/src/Directory.Build.targets
-	sha = e2606657b68d2980cc3cae181c59baa3d847ab75
-	etag = a69e9c33e8b3efde55f99aa22a3c5a8db371cf5142f7db78e4e2984d805f287e
+	sha = 83d73781f82a05b805c98b70219c32a47c096fbe
+	etag = 7b62ae495bdfb2dcca473709323ab0d5cf2bb7637e7bff3250ae9267839069ef
 	weak
 [file "src/kzu.snk"]
 	url = https://github.com/devlooped/oss/blob/main/src/kzu.snk
@@ -147,4 +142,9 @@
 	url = https://github.com/devlooped/.github/blob/main/Gemfile
 	sha = f2dc1370469bec1b2d32d82faf659b050cdc7e2a
 	etag = d45832acd078778ffebf260000f6d25172a131f51684744d7e982da2a47170ce
+	weak
+[file ".github/.github_changelog_generator"]
+	url = https://github.com/devlooped/oss/blob/main/.github/.github_changelog_generator
+	sha = b7ce2bedba3fe467b8bc252c372cd36bbde259a5
+	etag = 28145d505ce95b57628ab368bb12744300d5f539d3651c346e3c0c3f772ffa7b
 	weak

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -39,6 +39,9 @@
     <!-- Use Directory.Packages.props if possible. NOTE: other MSBuild SDKs (i.e. NoTargets/Traversal) do not support central packages -->
     <ManagePackageVersionsCentrally Condition="Exists('$(MSBuildThisFileDirectory)Directory.Packages.props') AND ('$(MSBuildProjectExtension)' == '.csproj' OR '$(MSBuildProjectExtension)' == '.vbproj')">true</ManagePackageVersionsCentrally>
     <RestoreSources>https://api.nuget.org/v3/index.json;https://pkg.kzu.io/index.json;$(RestoreSources)</RestoreSources>
+
+    <!-- Ensure MSBuild tooling can access package artifacts always via PKG_[PackageId] -->
+    <GeneratePathProperty>true</GeneratePathProperty>
   </PropertyGroup>
 
   <PropertyGroup Label="Build">
@@ -80,6 +83,9 @@
     
     <!-- Preserve transitively copied content in VS: https://github.com/dotnet/msbuild/issues/1054#issuecomment-847959047 -->
     <MSBuildCopyContentTransitively>true</MSBuildCopyContentTransitively>
+    
+    <!-- Global tools should run on whatever latest runtime is installed. See https://docs.microsoft.com/en-us/dotnet/core/versions/selection#framework-dependent-apps-roll-forward -->
+    <RollForward>LatestMinor</RollForward>
   </PropertyGroup>
 
   <PropertyGroup Label="StrongName" Condition="Exists('$(MSBuildThisFileDirectory)kzu.snk')">

--- a/src/Directory.Build.targets
+++ b/src/Directory.Build.targets
@@ -42,7 +42,7 @@
           Pack="true" PackagePath="%(Filename)%(Extension)"
           Condition="Exists('$(MSBuildThisFileDirectory)icon.png') and !Exists('$(MSBuildProjectDirectory)icon.png')" />
 
-    <None Include="$(MSBuildThisFileDirectory)readme.md" Link="readme.md" Visible="false" 
+    <None Include="$(MSBuildThisFileDirectory)readme.md" Link="readme.md"  
           Pack="true" PackagePath="%(Filename)%(Extension)"
           Condition="Exists('$(MSBuildThisFileDirectory)readme.md') and !Exists('$(MSBuildProjectDirectory)readme.md')" />
   </ItemGroup>
@@ -109,6 +109,7 @@
 
   <ItemGroup>
     <!-- Make these available via ThisAssembly.Project -->
+    <ProjectProperty Include="RepositoryBranch" />
     <ProjectProperty Include="RepositorySha" />
     <ProjectProperty Include="RepositoryCommit" />
   </ItemGroup>


### PR DESCRIPTION
# devlooped/oss

- Move changelog config to .github, switch to gem https://github.com/devlooped/oss/commit/b7ce2be
- Global tools should run on whatever latest runtime is installed. https://github.com/devlooped/oss/commit/b65c8f1
- Ensure MSBuild tooling can access package artifacts always via PKG_[PackageId] https://github.com/devlooped/oss/commit/cc6922f
- Make src-level readme visible for easier editing https://github.com/devlooped/oss/commit/bfe0f2a
- Add RepositoryBranch as a ThisAssembly.Project property https://github.com/devlooped/oss/commit/83d7378
- Add icon prefix to match dependabot https://github.com/devlooped/oss/commit/2a39a42