### PR TITLE
Fix root object replacement in JsonPoke

### DIFF
--- a/src/JsonPoke/JsonPoke.cs
+++ b/src/JsonPoke/JsonPoke.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Globalization;
 using System.IO;
@@ -84,8 +84,16 @@ public class JsonPoke : Task
 
         var jvalue = new Lazy<JToken>(GetValue);
 
-        var json = JObject.Parse(content!);
+        var json = JToken.Parse(content!);
         var matches = JPathExpr.Matches(Query).Cast<Match>().ToList();
+
+        void SetToken(JToken node, JToken value)
+        {
+            if (node.Parent == null)
+                json = value;
+            else
+                node.Replace(value);
+        }
         // If we have any part of teh expression using our own "from end" syntax for array indexing, 
         // we know we'll be inserting a *new* 
         var nodes = matches.Any(m => m.Groups["end"].Success) ? new() : json.SelectTokens(Query).ToList();
@@ -204,7 +212,7 @@ public class JsonPoke : Task
                 // We'll be doing complex object replacement, 
                 // so just replace the whole thing in one shot, 
                 // no smarts for target-type selection.
-                node.Replace(jvalue.Value);
+                SetToken(node, jvalue.Value);
                 AddResult(jvalue.Value, i);
                 continue;
             }
@@ -230,7 +238,7 @@ public class JsonPoke : Task
                 _ => jvalue.Value,
             };
 
-            node.Replace(value);
+            SetToken(node, value);
             AddResult(value, i);
         }
 

--- a/src/Tests/Poke.targets
+++ b/src/Tests/Poke.targets
@@ -1,4 +1,4 @@
-<Project>
+﻿<Project>
 
   <UsingTask TaskName="Error" AssemblyName="Microsoft.Build.Tasks.Core, PublicKeyToken=b03f5f7f11d50a3a" />
   <UsingTask TaskName="Message" AssemblyName="Microsoft.Build.Tasks.Core, PublicKeyToken=b03f5f7f11d50a3a" />

--- a/src/Tests/Poke.targets
+++ b/src/Tests/Poke.targets
@@ -1,4 +1,4 @@
-﻿<Project>
+<Project>
 
   <UsingTask TaskName="Error" AssemblyName="Microsoft.Build.Tasks.Core, PublicKeyToken=b03f5f7f11d50a3a" />
   <UsingTask TaskName="Message" AssemblyName="Microsoft.Build.Tasks.Core, PublicKeyToken=b03f5f7f11d50a3a" />
@@ -282,6 +282,30 @@
     <JsonPoke ContentPath="sample.json" Query="$(Query)" Value="false">
       <Output TaskParameter="Result" ItemName="Changed" />
     </JsonPoke>
+  </Target>
+
+  <Target Name="PokeRootObject">
+    <PropertyGroup>
+      <Query>$.a</Query>
+      <Expected>Value of a</Expected>
+    </PropertyGroup>
+
+    <ItemGroup>
+      <Value Include="metadata">
+        <a>Value of a</a>
+      </Value>
+      <Property Include="a" />
+    </ItemGroup>
+
+    <JsonPoke Content="{}" Query="$" Value="@(Value)" Properties="@(Property)">
+      <Output TaskParameter="Content" PropertyName="Content" />
+    </JsonPoke>
+
+    <JsonPeek Content="$(Content)" Query="$(Query)">
+      <Output TaskParameter="Result" PropertyName="Actual" />
+    </JsonPeek>
+
+    <Error Condition="'$(Expected)' != '$(Actual)'" Text="Expected $(Expected) but was $(Actual)" />
   </Target>
 
   <Target Name="PokeContentJsonProperty">

--- a/src/Tests/Tests.cs
+++ b/src/Tests/Tests.cs
@@ -143,6 +143,42 @@ public record Tests(ITestOutputHelper Output)
     }
 
     [Fact]
+    public void PokeRootWithMetadata()
+    {
+        var value = new TaskItem("metadata");
+        value.SetMetadata("a", "Value of a");
+
+        var poke = new JsonPoke
+        {
+            Content = "{}",
+            Query = "$",
+            Value = new[] { value },
+            Properties = new[] { new TaskItem("a") },
+        };
+
+        Assert.True(poke.Execute());
+
+        dynamic obj = JObject.Parse(poke.Content!);
+        Assert.Equal("Value of a", (string?)obj?.a);
+    }
+
+    [Fact]
+    public void PokeRootWithRawValue()
+    {
+        var poke = new JsonPoke
+        {
+            Content = "{}",
+            Query = "$",
+            RawValue = @"{ ""a"": ""Value of a"" }",
+        };
+
+        Assert.True(poke.Execute());
+
+        dynamic obj = JObject.Parse(poke.Content!);
+        Assert.Equal("Value of a", (string?)obj?.a);
+    }
+
+    [Fact]
     public void AddObjectArray()
     {
         var poke = new JsonPoke


### PR DESCRIPTION
Fixes #85

When `Query` is `$`, `node.Replace()` fails with `InvalidOperationException: The parent is missing` because the root token has no parent.

## Changes

- Parse JSON with `JToken.Parse` instead of `JObject.Parse`
- Add `SetToken` helper that reassigns the root token when `node.Parent == null` instead of calling `Replace`
- Add unit tests (`PokeRootWithMetadata`, `PokeRootWithRawValue`) and MSBuild integration target (`PokeRootObject`)

## Repro (before fix)

```xml
<JsonPoke Content="{}" Query="$" Value="@(VersionFile)" Properties="a" />
```

With `VersionFile` item metadata `a=Value of a`, this threw at `JsonPoke.cs:207`.

## After fix

Produces `{ "a": "Value of a" }` as expected.