### PR TITLE
Bump Microsoft.Build.Utilities.Core to 17.14.28

### DIFF
--- a/src/JsonPeek/JsonPeek.csproj
+++ b/src/JsonPeek/JsonPeek.csproj
@@ -11,7 +11,7 @@
 
   <ItemGroup>
     <PackageReference Include="NuGetizer" Version="0.9.1" />
-    <PackageReference Include="Microsoft.Build.Utilities.Core" Version="15.9.20" Pack="false" />
+    <PackageReference Include="Microsoft.Build.Utilities.Core" Version="17.14.28" Pack="false" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" PrivateAssets="all" />
   </ItemGroup>
 

--- a/src/JsonPoke/JsonPoke.csproj
+++ b/src/JsonPoke/JsonPoke.csproj
@@ -15,7 +15,7 @@
 
   <ItemGroup>
     <PackageReference Include="NuGetizer" Version="0.9.1" />
-    <PackageReference Include="Microsoft.Build.Utilities.Core" Version="15.9.20" Pack="false" />
+    <PackageReference Include="Microsoft.Build.Utilities.Core" Version="17.14.28" Pack="false" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" PrivateAssets="all" />
   </ItemGroup>
 

--- a/src/Tests/Tests.csproj
+++ b/src/Tests/Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>
@@ -9,9 +9,9 @@
     <PackageReference Include="xunit" Version="2.9.3" />
     <PackageReference Include="xunit.runner.visualstudio" Version="3.0.2" />
 
-    <PackageReference Include="Microsoft.Build" Version="17.3.2" />
-    <PackageReference Include="Microsoft.Build.Tasks.Core" Version="17.3.2" />
-    <PackageReference Include="Microsoft.Build.Utilities.Core" Version="17.3.2" />
+    <PackageReference Include="Microsoft.Build" Version="17.14.28" />
+    <PackageReference Include="Microsoft.Build.Tasks.Core" Version="17.14.28" />
+    <PackageReference Include="Microsoft.Build.Utilities.Core" Version="17.14.28" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
   </ItemGroup>
 


### PR DESCRIPTION
Bumps Microsoft.Build.Utilities.Core to the latest stable 17.x release (17.14.28) in JsonPeek and JsonPoke.

Also aligns the Tests project Microsoft.Build.* packages to 17.14.28 and upgrades Tests to net9.0, which is required for the 17.12+ MSBuild packages that no longer ship net6.0 binaries.